### PR TITLE
Add StateChanger

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -12,13 +12,17 @@ android {
 
     defaultConfig {
         applicationId = "io.github.wellingtoncosta.customviews"
-        minSdkVersion(16)
+        minSdkVersion(21)
         targetSdkVersion(29)
         versionCode = 1
         versionName = "1.0"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {
             useSupportLibrary = true
+        }
+
+        kotlinOptions {
+            jvmTarget = "1.8"
         }
     }
 
@@ -89,6 +93,10 @@ dependencies {
     implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0")
     implementation("androidx.constraintlayout:constraintlayout:1.1.3")
     implementation("androidx.viewpager2:viewpager2:1.0.0")
+    implementation("androidx.lifecycle:lifecycle-runtime:2.2.0")
+    implementation ("androidx.lifecycle:lifecycle-common-java8:2.2.0")
+    implementation ("androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0")
+    implementation ("androidx.lifecycle:lifecycle-livedata-ktx:2.2.0")
 
     // Dagger
     implementation("com.google.dagger:dagger:2.26")

--- a/app/src/main/java/io/github/wellingtoncosta/customviews/core/navigation/ScreenKey.kt
+++ b/app/src/main/java/io/github/wellingtoncosta/customviews/core/navigation/ScreenKey.kt
@@ -1,4 +1,4 @@
-package io.github.wellingtoncosta.customviews.presentation.navigation
+package io.github.wellingtoncosta.customviews.core.navigation
 
 import android.os.Parcelable
 import com.zhuinden.simplestack.navigator.DefaultViewKey

--- a/app/src/main/java/io/github/wellingtoncosta/customviews/core/navigation/ServiceProvider.kt
+++ b/app/src/main/java/io/github/wellingtoncosta/customviews/core/navigation/ServiceProvider.kt
@@ -1,4 +1,4 @@
-package io.github.wellingtoncosta.customviews.presentation.navigation
+package io.github.wellingtoncosta.customviews.core.navigation
 
 import com.zhuinden.simplestack.ScopeKey
 import com.zhuinden.simplestack.ScopedServices

--- a/app/src/main/java/io/github/wellingtoncosta/customviews/core/navigation/ViewExt.kt
+++ b/app/src/main/java/io/github/wellingtoncosta/customviews/core/navigation/ViewExt.kt
@@ -1,0 +1,14 @@
+package io.github.wellingtoncosta.customviews.core.navigation
+
+import android.view.View
+import android.view.ViewGroup
+import kotlinx.coroutines.CoroutineScope
+
+val View.viewScope get() = findTopMostParentWithScope()
+
+private fun View.findTopMostParentWithScope(): CoroutineScope {
+    val scope = getTag(VIEW_COROUTINE_SCOPE_KEY) as CoroutineScope?
+    return scope ?: checkNotNull(parent as ViewGroup) {
+        "CoroutineScope is not set for this view-tree hierarchy."
+    }.findTopMostParentWithScope()
+}

--- a/app/src/main/java/io/github/wellingtoncosta/customviews/core/navigation/ViewStateChanger.kt
+++ b/app/src/main/java/io/github/wellingtoncosta/customviews/core/navigation/ViewStateChanger.kt
@@ -10,6 +10,8 @@ import com.zhuinden.simplestack.navigator.changehandlers.FadeViewChangeHandler
 import io.github.wellingtoncosta.customviews.R
 import kotlinx.coroutines.*
 
+const val VIEW_COROUTINE_SCOPE_KEY = R.id.view_coroutine_scope
+
 class ViewStateChanger(
     private val activity: Activity,
     private val root: ViewGroup
@@ -22,7 +24,7 @@ class ViewStateChanger(
             .inflate(newKey.layout(), root, false)
 
         val viewScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
-        newView.setTag(R.id.view_coroutine_scope, viewScope)
+        newView.setTag(VIEW_COROUTINE_SCOPE_KEY, viewScope)
 
         val previousView = root.getChildAt(0)
         Navigator.persistViewToState(previousView)
@@ -34,7 +36,7 @@ class ViewStateChanger(
             return
         }
 
-        val previousViewScope = previousView.getTag(R.id.view_coroutine_scope) as CoroutineScope?
+        val previousViewScope = previousView.getTag(VIEW_COROUTINE_SCOPE_KEY) as CoroutineScope?
         previousViewScope?.cancel()
 
         val viewChangeHandler = when (stateChange.direction) {

--- a/app/src/main/java/io/github/wellingtoncosta/customviews/core/navigation/ViewStateChanger.kt
+++ b/app/src/main/java/io/github/wellingtoncosta/customviews/core/navigation/ViewStateChanger.kt
@@ -1,0 +1,51 @@
+package io.github.wellingtoncosta.customviews.core.navigation
+
+import android.app.Activity
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import com.zhuinden.simplestack.StateChange
+import com.zhuinden.simplestack.StateChanger
+import com.zhuinden.simplestack.navigator.Navigator
+import com.zhuinden.simplestack.navigator.changehandlers.FadeViewChangeHandler
+import io.github.wellingtoncosta.customviews.R
+import io.github.wellingtoncosta.customviews.presentation.navigation.ScreenKey
+import kotlinx.coroutines.*
+
+class ViewStateChanger(
+    private val activity: Activity,
+    private val root: ViewGroup
+) : StateChanger {
+    override fun handleStateChange(stateChange: StateChange, completionCallback: StateChanger.Callback) {
+        val newKey = stateChange.topNewKey<ScreenKey>()
+        val previousKey = stateChange.topPreviousKey<ScreenKey?>()
+
+        val newView = LayoutInflater.from(stateChange.createContext(activity, newKey))
+            .inflate(newKey.layout(), root, false)
+
+        val viewScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+        newView.setTag(R.id.view_coroutine_scope, viewScope)
+
+        val previousView = root.getChildAt(0)
+        Navigator.persistViewToState(previousView)
+        Navigator.restoreViewFromState(newView)
+
+        if (previousKey == null || previousView == null) {
+            root.addView(newView)
+            completionCallback.stateChangeComplete()
+            return
+        }
+
+        val previousViewScope = previousView.getTag(R.id.view_coroutine_scope) as CoroutineScope?
+        previousViewScope?.cancel()
+
+        val viewChangeHandler = when (stateChange.direction) {
+            StateChange.FORWARD -> newKey.viewChangeHandler()
+            StateChange.BACKWARD -> previousKey.viewChangeHandler()
+            else -> FadeViewChangeHandler()
+        }
+
+        viewChangeHandler.performViewChange(root, previousView, newView, stateChange.direction) {
+            completionCallback.stateChangeComplete()
+        }
+    }
+}

--- a/app/src/main/java/io/github/wellingtoncosta/customviews/core/navigation/ViewStateChanger.kt
+++ b/app/src/main/java/io/github/wellingtoncosta/customviews/core/navigation/ViewStateChanger.kt
@@ -8,7 +8,6 @@ import com.zhuinden.simplestack.StateChanger
 import com.zhuinden.simplestack.navigator.Navigator
 import com.zhuinden.simplestack.navigator.changehandlers.FadeViewChangeHandler
 import io.github.wellingtoncosta.customviews.R
-import io.github.wellingtoncosta.customviews.presentation.navigation.ScreenKey
 import kotlinx.coroutines.*
 
 class ViewStateChanger(

--- a/app/src/main/java/io/github/wellingtoncosta/customviews/presentation/MainActivity.kt
+++ b/app/src/main/java/io/github/wellingtoncosta/customviews/presentation/MainActivity.kt
@@ -7,6 +7,7 @@ import androidx.appcompat.app.AppCompatActivity
 import com.zhuinden.simplestack.History
 import com.zhuinden.simplestack.navigator.Navigator
 import io.github.wellingtoncosta.customviews.core.navigation.ServiceProvider
+import io.github.wellingtoncosta.customviews.core.navigation.ViewStateChanger
 import io.github.wellingtoncosta.customviews.presentation.users.UsersScreenKey
 
 class MainActivity : AppCompatActivity() {
@@ -15,11 +16,13 @@ class MainActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
 
         val mainContainer = MainContainer(this)
-
         setContentView(mainContainer)
+
+        val stateChanger = ViewStateChanger(this, mainContainer)
 
         Navigator
             .configure()
+            .setStateChanger(stateChanger)
             .setScopedServices(ServiceProvider())
             .install(this, mainContainer, History.of(UsersScreenKey()))
     }

--- a/app/src/main/java/io/github/wellingtoncosta/customviews/presentation/MainActivity.kt
+++ b/app/src/main/java/io/github/wellingtoncosta/customviews/presentation/MainActivity.kt
@@ -6,7 +6,7 @@ import android.widget.FrameLayout
 import androidx.appcompat.app.AppCompatActivity
 import com.zhuinden.simplestack.History
 import com.zhuinden.simplestack.navigator.Navigator
-import io.github.wellingtoncosta.customviews.presentation.navigation.ServiceProvider
+import io.github.wellingtoncosta.customviews.core.navigation.ServiceProvider
 import io.github.wellingtoncosta.customviews.presentation.users.UsersScreenKey
 
 class MainActivity : AppCompatActivity() {

--- a/app/src/main/java/io/github/wellingtoncosta/customviews/presentation/users/UsersScreenKey.kt
+++ b/app/src/main/java/io/github/wellingtoncosta/customviews/presentation/users/UsersScreenKey.kt
@@ -2,8 +2,8 @@ package io.github.wellingtoncosta.customviews.presentation.users
 
 import com.zhuinden.simplestack.ServiceBinder
 import io.github.wellingtoncosta.customviews.R
-import io.github.wellingtoncosta.customviews.presentation.navigation.ScreenKey
-import io.github.wellingtoncosta.customviews.presentation.navigation.ServiceProvider
+import io.github.wellingtoncosta.customviews.core.navigation.ScreenKey
+import io.github.wellingtoncosta.customviews.core.navigation.ServiceProvider
 import kotlinx.android.parcel.Parcelize
 
 @Parcelize data class UsersScreenKey(

--- a/app/src/main/java/io/github/wellingtoncosta/customviews/presentation/users/UsersUiStates.kt
+++ b/app/src/main/java/io/github/wellingtoncosta/customviews/presentation/users/UsersUiStates.kt
@@ -1,0 +1,27 @@
+package io.github.wellingtoncosta.customviews.presentation.users
+
+import androidx.core.view.isVisible
+import io.github.wellingtoncosta.customviews.databinding.ScreenUsersBinding
+import io.github.wellingtoncosta.customviews.domain.entity.User
+
+sealed class UsersUiStates {
+    open operator fun invoke(viewBinding: ScreenUsersBinding) = Unit
+
+    object Loading : UsersUiStates() {
+        override fun invoke(viewBinding: ScreenUsersBinding) = with(viewBinding) {
+            progress.isVisible = true
+            usersRecyclerView.isVisible = false
+        }
+    }
+
+    object FinishedLoading : UsersUiStates() {
+        override fun invoke(viewBinding: ScreenUsersBinding) = with(viewBinding) {
+            progress.isVisible = false
+            usersRecyclerView.isVisible = true
+        }
+    }
+
+    data class Success(val users: List<User>) : UsersUiStates()
+
+    data class Failure(val error: Throwable) : UsersUiStates()
+}

--- a/app/src/main/java/io/github/wellingtoncosta/customviews/presentation/users/detail/UserDetailScreenKey.kt
+++ b/app/src/main/java/io/github/wellingtoncosta/customviews/presentation/users/detail/UserDetailScreenKey.kt
@@ -2,7 +2,7 @@ package io.github.wellingtoncosta.customviews.presentation.users.detail
 
 import io.github.wellingtoncosta.customviews.R
 import io.github.wellingtoncosta.customviews.domain.entity.User
-import io.github.wellingtoncosta.customviews.presentation.navigation.ScreenKey
+import io.github.wellingtoncosta.customviews.core.navigation.ScreenKey
 import kotlinx.android.parcel.Parcelize
 
 @Parcelize data class UserDetailScreenKey(

--- a/app/src/main/res/values/ids.xml
+++ b/app/src/main/res/values/ids.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <item name="view_coroutine_scope" type="id"/>
+</resources>


### PR DESCRIPTION
In this pull request I'm adding a `ViewStateChanger` to control the inflation of new `Views` using `SimpleStack.StateChanger.`.

This is useful to do a lot of things. For now, I'm also adding CoroutineScope support for `Views`, this way we don't need to manually creates and cancel Scopes for Views.

**Usage**

    viewScope.launch {}

Also I'm removing the usage of `LiveData` on `UsersScreen` to leverages on Kotlin Flow.